### PR TITLE
chore: scaffold ai governance

### DIFF
--- a/ai/ADR/0000-INDEX.md
+++ b/ai/ADR/0000-INDEX.md
@@ -1,0 +1,5 @@
+# AI Decision Records Index
+
+This file lists all ADRs and their current status.
+
+- _No ADRs yet_

--- a/ai/ADR/TEMPLATE.md
+++ b/ai/ADR/TEMPLATE.md
@@ -1,0 +1,34 @@
+---
+id: ADR-<auto or manual>
+title: <short title>
+status: Proposed  # Proposed | Accepted | Deprecated | Superseded
+date: YYYY-MM-DD
+review_after: YYYY-MM-DD      # review date
+sunset_if:                    # sunset conditions
+  - "Node LTS > 22 or perf regression > 10%"
+evidence_strength: pilot|limited|strong
+tags: [domain:<sub>, risk:<low|med|high>, scope:<code|infra|process>]
+related_runs: []             # /ai/Runs/...yaml
+related_playbooks: []        # /ai/Playbooks/...md
+related_policies: []         # /ai/Policies/...md
+owner: human|agent:<name>
+---
+
+## Context
+<background, constraints, related modules or tickets>
+
+## Decision
+<chosen approach: actionable and verifiable>
+
+## Consequences
+<positive/negative effects, risks, rollback plan, monitoring metrics>
+
+## Evidence
+- PR/Commit: <links>
+- Bench/Tests: <numbers>
+
+## How to Apply
+<implementation steps, corresponding Playbook>
+
+## Alternatives Considered
+<other options and reasons not chosen>

--- a/ai/GLOSSARY.md
+++ b/ai/GLOSSARY.md
@@ -1,0 +1,5 @@
+# Glossary
+
+| Term | Definition |
+|------|------------|
+| _TBD_ | _Add project-specific terms here_ |

--- a/ai/Lessons/LESSONS.md
+++ b/ai/Lessons/LESSONS.md
@@ -1,0 +1,5 @@
+# Lessons (Pending ADR)
+> Tag with: #build #test #ops #perf #security
+> Upgrade rule: same topic shows ≥2 successful Runs with evidence before promoting to ADR.
+
+- _No lessons yet_

--- a/ai/Policies/GUARDRAILS.md
+++ b/ai/Policies/GUARDRAILS.md
@@ -1,0 +1,13 @@
+# Guardrails
+## Never Touch
+- /infra/**
+- /secrets/**
+- /migrations/manual/**
+
+## Must Run Before PR
+- `npm run lint && npm run typecheck && npm test -- --ci`
+
+## PR Checklist (Agent must verify)
+- [ ] Link at least one ADR or Playbook
+- [ ] Attach test or benchmark evidence
+- [ ] If change exceeds 500 lines, split into multiple PRs

--- a/ai/Prompts/builder.md
+++ b/ai/Prompts/builder.md
@@ -1,0 +1,3 @@
+## System
+You are the Builder. Include refs to ADR/Playbook and write `/ai/Runs/*` upon finish.
+@include: ./common.md

--- a/ai/Prompts/common.md
+++ b/ai/Prompts/common.md
@@ -1,0 +1,3 @@
+- Always search `/ai/ADR/0000-INDEX.md` and `/ai/Playbooks` before implementation.
+- Cite the exact ADR or Playbook in `/ai/Runs` refs.
+- Refuse actions that violate `/ai/Policies/GUARDRAILS.md`.

--- a/ai/README.md
+++ b/ai/README.md
@@ -1,0 +1,23 @@
+# AI Folder Guide
+
+## Quick Paths
+| Goal | Read First | Then | Output |
+|---|---|---|---|
+| Solve one-off task | /ai/Playbooks | follow steps | /ai/Runs/<run>.yaml |
+| Establish long-term rule | /ai/ADR/0000-INDEX.md | draft new ADR | ADR PR |
+| Unsure if worth ADR | /ai/Lessons/LESSONS.md | record lesson | evaluate later |
+
+```mermaid
+flowchart TD
+A[Start Task] --> B{Playbook exists?}
+B -- Yes --> C[Follow Playbook]
+B -- No --> D{Long-term decision?}
+D -- Yes --> E[Draft ADR (Proposed)]
+D -- No --> F[Log Lesson]
+C --> G[Create Run YAML]
+E --> G
+F --> G
+G --> H{Result stable?}
+H -- Yes --> I[Promote to Playbook or Accept ADR]
+H -- No --> J[Keep in Lessons / observe]
+```

--- a/ai/Runs/schema.yaml
+++ b/ai/Runs/schema.yaml
@@ -1,0 +1,49 @@
+required:
+  - id
+  - date
+  - repo_sha
+  - agent
+  - model
+  - task
+  - steps
+  - result
+  - links
+  - evidence
+properties:
+  id: { type: string }
+  date: { type: string, format: date }
+  repo_sha: { type: string, description: "git rev-parse HEAD" }
+  agent: { type: string }
+  model: { type: string }
+  tool_versions: { type: object }
+  prompt_digest: { type: string }
+  seed: { type: integer, nullable: true }
+  cost:
+    type: object
+    properties:
+      tokens_in: {type: number}
+      tokens_out: {type: number}
+      runtime_sec: {type: number}
+  task: { type: string }
+  inputs: { type: object }
+  steps: { type: array, items: { type: string } }
+  outputs: { type: object }
+  result: { type: string, enum: ["pass","fail","partial"] }
+  error_type: { type: string, nullable: true }
+  refs:
+    type: object
+    properties:
+      adrs: { type: array, items: { type: string } }
+      playbooks: { type: array, items: { type: string } }
+      policies: { type: array, items: { type: string } }
+  evidence:
+    type: object
+    properties:
+      tests: { type: array, items: { type: string } }
+      screenshots: { type: array, items: { type: string } }
+      logs: { type: array, items: { type: string } }
+  links:
+    type: object
+    properties:
+      pr: { type: string }
+      issues: { type: array, items: { type: string } }

--- a/ai/TEMP-NOTES.md
+++ b/ai/TEMP-NOTES.md
@@ -1,0 +1,16 @@
+# TEMPORARY NOTES – May delete or merge later
+**Purpose:** transient scratchpad for AI assistants to track decisions/TODOs.
+
+## Findings
+- Need CI workflow `.github/workflows/ai-governance.yml` with ADR index and Run schema checks.
+- Runs must link at least one ADR or Playbook; missing links should fail CI.
+- ADRs require `review_after` and `sunset_if` fields for clarity and retirement.
+
+## TODOs
+- [ ] Add base `/ai` structure (ADR, Runs, Lessons, Playbooks, Policies, Prompts, Glossary, README).
+- [ ] Implement `schema.yaml` for Runs with cost, tool versions, refs, evidence.
+- [ ] Create `Policies/GUARDRAILS.md` to list forbidden paths and mandatory tests.
+- [ ] Draft `Prompts/common.md` and role-specific prompts using `@include` tags.
+- [ ] Establish `Lessons/LESSONS.md` with tagging rules and upgrade criteria.
+
+*This file is temporary; feel free to append, refactor, or remove once formal ADRs/Playbooks cover these points.*


### PR DESCRIPTION
## Summary
- scaffold AI governance structure with README, ADR template, run schema, prompts, lessons, and guardrails
- add temporary notes for future AI contributions

## Testing
- `npm run lint` *(fails: ESLint couldn't find config, svelte-kit and pylint missing)*
- `npm run typecheck` *(fails: Missing script "typecheck")*
- `npm test -- --ci` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688faf3aad5483239ac2efc073871df5