### PR TITLE
docs: add reviewer and tester prompts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@
 
 ## 9. Common References
 - **Glossary**: `/ai/GLOSSARY.md`.
-- **Prompts**: `/ai/Prompts/common.md` + role-specific files.
+- **Prompts**: `/ai/Prompts/common.md` + role-specific files (`builder.md`, `reviewer.md`, `tester.md`).
 - **Playbooks**: versioned headers with compatibility matrix and changelog.
 
 ---

--- a/ai/Playbooks/role-prompts.md
+++ b/ai/Playbooks/role-prompts.md
@@ -1,0 +1,23 @@
+# Playbook: Managing Role Prompts
+
+status: Draft
+version: 0.1.0
+compatibility:
+  node: ">=20"
+  python: ">=3.10"
+changelog:
+  - version: 0.1.0
+    date: 2025-08-03
+    notes: Initial draft for adding role prompt files.
+
+## Purpose
+Guide contributors on creating role-specific prompt files in `/ai/Prompts`.
+
+## Steps
+1. Create `<role>.md` under `/ai/Prompts`.
+2. Begin with a `## System` heading describing the role.
+3. Include shared guidance via `@include: ./common.md`.
+4. Add role-specific instructions.
+5. Update `AGENTS.md` or relevant README to document the new role files.
+6. Execute `npm run lint && npm run typecheck && npm test -- --ci`.
+7. Record the change in `/ai/Runs/<date>/run-<date>-<seq>.yaml` referencing this Playbook.

--- a/ai/Prompts/reviewer.md
+++ b/ai/Prompts/reviewer.md
@@ -1,0 +1,3 @@
+## System
+You are the Reviewer. Critically evaluate changes for adherence to ADRs, Playbooks, and project policies. Ensure authors update `/ai/Runs/*` with your findings.
+@include: ./common.md

--- a/ai/Prompts/tester.md
+++ b/ai/Prompts/tester.md
@@ -1,0 +1,3 @@
+## System
+You are the Tester. Run project checks and report failures. Confirm results are captured in `/ai/Runs/*` and that referenced ADRs or Playbooks are respected.
+@include: ./common.md

--- a/ai/Runs/2025-08-03/run-2025-08-03-001.yaml
+++ b/ai/Runs/2025-08-03/run-2025-08-03-001.yaml
@@ -1,0 +1,10 @@
+repo_sha: 54d283b6ccac1136bff283a72bed8a4769a1c5c0
+prompt_digest: 93186f35997dd73ceb4a821014aae725ccc1686ac35b9dd4afeb974b8ec655f9
+tool_versions:
+  node: v22.17.1
+  python: 3.12.10
+cost: 0
+refs:
+  playbooks:
+    - ai/Playbooks/role-prompts.md
+  adrs: []


### PR DESCRIPTION
## Summary
- add reviewer and tester role prompt files that include common guidance
- document available prompt roles in AGENTS
- provide a playbook for managing role prompt files

## Testing
- `npm run lint` *(fails: eslint not found)*
- `npm run typecheck` *(fails: Missing script "typecheck")*
- `npm test -- --ci` *(fails: Missing script "test")*

## Run
- `ai/Runs/2025-08-03/run-2025-08-03-001.yaml`

## References
- `ai/Playbooks/role-prompts.md`

## Risk
- Low: documentation-only change.

## Rollback Plan
- Revert the commit.

------
https://chatgpt.com/codex/tasks/task_e_688fc0a2f62083239546f5f60e3a9693