### PR TITLE
docs: document lite workflow path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 - **Secrets/PII**: never print, store, or transmit. Redact in logs and PRs.
 
 ## 1. Start Here
-- Read `/ai/README.md` for navigation and the decision flow.
+- Read `/ai/README.md` for navigation and the decision flow. For quick experiments or internal notes, use the [Lite Workflow](ai/README.md#lite-workflow).
 - Search `/ai/ADR/0000-INDEX.md` and `/ai/Playbooks/` before coding. Prefer an existing ADR/Playbook over ad-hoc changes.
 
 ## 2. Environment & Reproducibility

--- a/ai/README.md
+++ b/ai/README.md
@@ -25,3 +25,11 @@ H -- No --> J[Keep in Lessons / observe]
 ## Run Schemas
 - **Standard (`ai/Runs/schema.yaml`)** – use for production-ready or collaborative tasks. Requires full metadata such as agent, model, steps, evidence, and links.
 - **Lite (`ai/Runs/schema-lite.yaml`)** – use for quick experiments or internal notes where only `id`, `date`, `repo_sha`, `task`, and `result` are mandatory.
+
+## Lite Workflow
+Use this path when experimenting or jotting quick internal notes.
+
+1. Check existing Playbooks and ADRs for relevant guidance.
+2. Perform the task.
+3. Log the outcome in `/ai/Runs/<date>/run-*.yaml` using [`schema-lite.yaml`](Runs/schema-lite.yaml).
+4. Optional: if the insight becomes repeatable or impactful, promote it to an ADR.

--- a/ai/Runs/2025-08-03/run-2025-08-03-005.yaml
+++ b/ai/Runs/2025-08-03/run-2025-08-03-005.yaml
@@ -1,0 +1,23 @@
+id: run-2025-08-03-005
+date: 2025-08-03
+repo_sha: e8b4fcb807bbee685e61a4e0bb96967dbf8a1faf
+agent: open-webui
+model: gpt-4o
+prompt_digest: 1e6a923c535f7bafbfae75dbfebaf5e18438171980fcd781d43eda461accb85d
+tool_versions:
+  node: v20.19.4
+  python: 3.12.10
+cost:
+  tokens_in: 0
+  tokens_out: 0
+  runtime_sec: 0
+task: Document lite workflow and link from AGENTS
+result: pass
+refs:
+  playbooks:
+    - ai/Playbooks/role-prompts.md
+evidence:
+  tests:
+    - "npm run lint" # failed: missing eslint config
+    - "npm run typecheck" # failed: svelte-kit not found
+    - "npm test -- --ci" # not run due to previous failures


### PR DESCRIPTION
## Summary
- document Lite Workflow path and minimal steps
- link Lite Workflow from AGENTS.md for quick experiment guidance
- add example run file using schema-lite

## Testing
- `npm run lint && npm run typecheck && npm test -- --ci` *(fails: ESLint config, missing svelte-kit & pylint)*
- `npm ci` *(fails: 403 Forbidden fetching packages)*

## Run
- `ai/Runs/2025-08-03/run-2025-08-03-005.yaml`

## References
- `ai/Playbooks/role-prompts.md`

## Risk
- Low; documentation only.

## Impact
- Clarifies when contributors may use a lighter Run schema.

## Rollback
- Revert this PR.

------
https://chatgpt.com/codex/tasks/task_e_688feecedae483238044e0cb0e2be836