### PR TITLE
Add retry handling for ElevenLabs voice lookup

### DIFF
--- a/ai/Runs/2025-08-04/run-2025-08-04-002.yaml
+++ b/ai/Runs/2025-08-04/run-2025-08-04-002.yaml
@@ -1,0 +1,13 @@
+repo_sha: f748f773fff395b29b3b4e2cca75692c5827494e
+prompt_digest: c7b7879c6e2ca4b581efc1cb7d44692dc6163fa97176455af9c9b99a98ccdab9
+tool_versions:
+  node: v20.19.4
+  npm: 11.4.2
+  python: 3.12.10
+cost: 0
+refs:
+  adrs: []
+  playbooks:
+    - ai/Playbooks/role-prompts.md
+  policies:
+    - ai/Policies/GUARDRAILS.md


### PR DESCRIPTION
## Summary
- add Tenacity-based retry with exponential backoff when fetching ElevenLabs voices
- log warnings on retry attempts and surface errors

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config)*
- `npm run typecheck` *(fails: Missing script: "typecheck")*
- `npm test -- --ci` *(fails: Missing script: "test")*

## Run
- `ai/Runs/2025-08-04/run-2025-08-04-002.yaml`

## References
- `ai/Playbooks/role-prompts.md`

## Risk
Low. Adds retry logic around external API call.

## Rollback Plan
Revert this PR to restore previous request behavior without retries.

------
https://chatgpt.com/codex/tasks/task_e_6890175fdacc8323907f71e6a0eb083c