### PR TITLE
docs: add manual docker refresh guide

### DIFF
--- a/ai/Runs/2025-08-04/run-2025-08-04-003.yaml
+++ b/ai/Runs/2025-08-04/run-2025-08-04-003.yaml
@@ -1,0 +1,13 @@
+id: run-2025-08-04-003
+date: 2025-08-04
+repo_sha: 8868b5f2ab009bc74eff9c3ea05cc94925dc23fc
+prompt_digest: fac5d9abca98664851ff675d596e13a3a5bf531cae21d3b9c895e6b3687b1fda
+task: add manual docker refresh guide
+result: success
+tool_versions:
+  node: v20.19.4
+  npm: 11.4.2
+cost: 0
+refs:
+  policies:
+    - ai/Policies/GUARDRAILS.md

--- a/contrib/dev-watch/README.md
+++ b/contrib/dev-watch/README.md
@@ -1,0 +1,28 @@
+# Manual Docker Updates for Development
+
+This guide explains how to refresh a local Open WebUI environment when not using file-watch tools.
+
+## Refresh the Running Container
+
+1. Pull the latest code:
+   ```bash
+   git pull
+   ```
+2. Restart the app container:
+   ```bash
+   docker compose restart open-webui
+   ```
+
+## Rebuild When Dependencies Change
+
+If `package.json`, `pyproject.toml`, or other dependencies change, rebuild the image before restarting:
+
+```bash
+docker compose build open-webui
+docker compose restart open-webui
+```
+
+## Guardrails
+
+- **Avoid** running `docker compose down -v`; it deletes volumes and data.
+- **Do not** remove `/app/backend/data`; this directory stores persistent application data.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -32,6 +32,10 @@ We've noticed an uptick in issues not directly related to Open WebUI but rather 
 
 - **Advanced Configurations**: Setting up reverse proxies for HTTPS and managing Docker deployments requires foundational knowledge. There are numerous online resources available to learn these skills. Ensuring you have this knowledge will greatly enhance your experience with Open WebUI and similar projects.
 
+### 🔁 Manual Docker Refresh
+
+If you're developing without file-watch tools, follow [../contrib/dev-watch/README.md](../contrib/dev-watch/README.md) for steps to pull changes, rebuild images, and restart containers safely.
+
 ## 💡 Contributing
 
 Looking to contribute? Great! Here's how you can help:


### PR DESCRIPTION
## Summary
- document manual container refresh steps for contributors working without file watch tools
- link manual docker refresh instructions in contributing guide
- record run metadata in `ai/Runs/2025-08-04/run-2025-08-04-003.yaml`

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run typecheck` *(fails: missing script)*
- `npm test -- --ci` *(fails: missing script)*

## Risk
Low — documentation only.

## Impact
Improves contributor workflow by documenting how to update and restart the Docker environment without file-watch tools.

## Rollback
Revert the commits.

Refs: `ai/Policies/GUARDRAILS.md`


------
https://chatgpt.com/codex/tasks/task_e_68903f25960c8323a89f63c9adf44c05