### PR TITLE
docs: clarify container refresh procedure

### DIFF
--- a/ai/Runs/2025-08-04/run-2025-08-04-004.yaml
+++ b/ai/Runs/2025-08-04/run-2025-08-04-004.yaml
@@ -1,0 +1,15 @@
+id: run-2025-08-04-004
+date: 2025-08-04
+repo_sha: 1a251f26b895f20526971610726b57733c15342e
+prompt_digest: a2add84369aaccbc371c8df954fcf3871d8b580d52d048baf8316f7668fa1798
+task: document container rebuild steps after git pull
+result: success
+tool_versions:
+  node: v22.17.1
+  npm: 10.9.2
+cost: 0
+refs:
+  playbooks:
+    - ai/Playbooks/role-prompts.md
+  policies:
+    - ai/Policies/GUARDRAILS.md

--- a/contrib/dev-watch/README.md
+++ b/contrib/dev-watch/README.md
@@ -4,23 +4,33 @@ This guide explains how to refresh a local Open WebUI environment when not using
 
 ## Refresh the Running Container
 
-1. Pull the latest code:
-   ```bash
-   git pull
-   ```
-2. Restart the app container:
-   ```bash
-   docker compose restart open-webui
-   ```
+The application source is baked into the Docker image. A `git pull` updates the host files but **does not** update a running container. After pulling new code, rebuild the image and recreate the container:
+
+```bash
+git pull
+docker compose build open-webui
+docker compose up -d --no-deps --force-recreate open-webui
+# or
+docker compose up -d --build open-webui
+```
 
 ## Rebuild When Dependencies Change
 
-If `package.json`, `pyproject.toml`, or other dependencies change, rebuild the image before restarting:
+If `package.json`, `pyproject.toml`, or other dependencies change, the above rebuild step is required before recreating the container.
 
-```bash
-docker compose build open-webui
-docker compose restart open-webui
+## Optional: Live Code with Bind Mounts
+
+For immediate code reflection without rebuilding, create a `docker-compose.override.yml` with a bind mount:
+
+```yaml
+# docker-compose.override.yml
+services:
+  open-webui:
+    volumes:
+      - .:/app
 ```
+
+`docker compose up -d open-webui` will then use the local source directly.
 
 ## Guardrails
 


### PR DESCRIPTION
## Summary
- clarify that `git pull` alone doesn't update the running Docker container
- document rebuilding & recreating the container with `docker compose`
- mention optional `docker-compose.override.yml` bind mount for live code

## Testing
- `npm run lint` *(fails: eslint not found)*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tiptap%2fcore)*
- `npm run typecheck` *(fails: Missing script)*
- `npm test -- --ci` *(fails: Missing script)*

## ADR / Playbook
- [ai/Playbooks/role-prompts.md](ai/Playbooks/role-prompts.md)

## Run
- `ai/Runs/2025-08-04/run-2025-08-04-004.yaml`

## Risk
Low – documentation only.

## Impact
Improves developer understanding of how to refresh Docker containers.

## Rollback
Revert this commit.

------
https://chatgpt.com/codex/tasks/task_e_689045b9fecc8323b3a7faf63de5ca85